### PR TITLE
Daemon fixes

### DIFF
--- a/contrib/restas-daemon.lisp
+++ b/contrib/restas-daemon.lisp
@@ -338,7 +338,16 @@
 ;;;; start swank server
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defpackage :swank-loader
+  (:use :cl)
+  (:export :init
+           :dump-image
+           :*source-directory*
+           :*fasl-directory*))
+
 (when *swankport*
+  (when *fasldir*
+    (defparameter swank-loader:*fasl-directory* *fasldir*))
   (asdf:oos 'asdf:load-op :swank))
 
 (when *swankport*


### PR DESCRIPTION
Some fixes for restas-daemon.lisp implemented:
1. Correctly start on Suse Enterprise Linux 10 64-bit
2. Correctly handle missed setting for daemon group (variable _group_)
3. Correctly handle _fasldir_ whane using SWANK, because SWANK uses swank-loader:_fasl-directory_ to detect correct place for FASL. Without this fix "/root/.cache" may be used for FASL cache.
