### PR TITLE
Fixed define-route macro if template variable is symbol.

### DIFF
--- a/src/route.lisp
+++ b/src/route.lisp
@@ -85,7 +85,10 @@
                               headers
                               decorators)
                         &body body)
-  (let* ((variables (iter (for var in (routes:template-variables (routes:parse-template template)))
+  (let* ((template-value (if (symbolp template)
+                             (symbol-value template)
+                             template))
+         (variables (iter (for var in (routes:template-variables (routes:parse-template template-value)))
                           (collect (list (intern (symbol-name var))
                                          (list 'cdr (list 'assoc var '*bindings*)))))))
     `(progn


### PR DESCRIPTION
Не совсем корректно работало:
(restas:define-route authenticate-page (_authenticate-url_) ...
