### PR TITLE
Fix for issues when ASDF2 doesn't contain *system-cache* variable.

### DIFF
--- a/contrib/restas-daemon.lisp
+++ b/contrib/restas-daemon.lisp
@@ -116,7 +116,7 @@
 (require 'asdf)
 
 (setf asdf::*user-cache* *fasldir*)
-(setf asdf::*system-cache* asdf::*user-cache*)
+#-asdf2 (setf asdf::*system-cache* asdf::*user-cache*)
 
 ;;;; create necessary directories
 


### PR DESCRIPTION
ASDF2 after release doesn't have "_system-cache_" parameter, so skip
its setup.

Checked on SBCL 1.0.55
