### PR TITLE
Proper handling of the unconfigured and missed SWANK

### DIFF
--- a/contrib/restas-daemon.lisp
+++ b/contrib/restas-daemon.lisp
@@ -359,8 +359,8 @@
   (asdf:oos 'asdf:load-op :swank))
 
 (when *swankport*
-  (setf swank:*use-dedicated-output-stream* nil)
-  (swank:create-server :port *swankport*
+  (setf (symbol-value (read-from-string "swank:*use-dedicated-output-stream*")) nil)
+  (funcall (read-from-string "swank:create-server :port *swankport*")
                        :coding-system "utf-8-unix"
                        :dont-close t))
 


### PR DESCRIPTION
It is a rare situation but if no SWANK set up and SWANK is not configured in daemon then "restas-daemon.lisp" used to use SWANK symbols during load. This fix delays symbol look up to runtime.

Checked on latest Restas and SBCL 1.0.55
