### PR TITLE
Really fix support for :content-type in define-module.

### DIFF
--- a/src/route.lisp
+++ b/src/route.lisp
@@ -130,13 +130,11 @@
   (destructuring-bind (&key content-type headers method requirement render-method decorators
                             variables additional-variables &allow-other-keys)
       (alexandria:hash-table-plist (gethash symbol (pkgmodule-traits-routes (symbol-package symbol))))
-    (cond
-      (content-type 
-       (setf (getf headers :content-type) content-type))
-      ((not (getf headers :content-type))
-       (setf (getf headers :content-type)
-             (or "text/html"))))
-
+    (setf (getf headers :content-type)
+          (or content-type
+              (getf headers :content-type)
+              (gethash :content-type (find-pkgmodule-traits (symbol-package symbol)))
+              "text/html"))
     (apply-decorators (make-instance 'route
                                      :template (route-template-from-symbol symbol module)
                                      :symbol symbol


### PR DESCRIPTION
After this fix, specifying content-type in define-module actually works.

Bug reported at https://groups.google.com/forum/#!topic/restas/nwwZLniZca8

This patch just calls `find-pkgmodule-traits` in `route.lisp`. However, would you prefer to define `pkgmodule-traits-content-type` in `module.lisp` and call it from `route.lisp` instead?
