### PR TITLE
Add method for module-context that takes a symbol and returns the contex...

### DIFF
--- a/src/module.lisp
+++ b/src/module.lisp
@@ -132,6 +132,12 @@
       (export route-symbol package))
     (distribute-route route-symbol)))
 
+(defmethod module-context ((module symbol))
+  "Get the context for a mounted module.
+
+MODULE should be the name used for mount-module."
+  (second (gethash module (pkgmodule-traits-modules *package*))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; pkgmodules
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
...t

for the module that was mounted (if any) in the current package with that name.
