### PR TITLE
Added :USE-EXISTING-PACKAGE module option.

### DIFF
--- a/core/module.lisp
+++ b/core/module.lisp
@@ -258,7 +258,8 @@ MODULE should be the name used for mount-module."
            (setf defpackage-options pkgoptions
                  traits pkgtraits)))
     `(eval-when (:compile-toplevel :load-toplevel :execute)
-       (defpackage ,name ,@defpackage-options)
+       ,@(unless (second (assoc :use-existing-package defpackage-options))
+           `((defpackage ,name ,@defpackage-options)))
        (register-pkgmodule-traits ',name ,@traits)
        (reconnect-all-routes))))
 


### PR DESCRIPTION
DEFINE-MODULE forms aren't handled by PACKAGE-INFERRED-SYSTEM in ASDF3,
so need to resort to separate package definitions.
