### PR TITLE
Adds Quicklisp's metadata

### DIFF
--- a/restas.asd
+++ b/restas.asd
@@ -6,6 +6,11 @@
 ;;;; Author: Moskvitin Andrey <archimag@gmail.com>
 
 (defsystem #:restas
+    :description "RESTAS is a Common Lisp web application framework, based
+on the Hunchentoot HTTP server It was developed to simplify development of
+web applications following the REST architectural style."
+    :author "Moskvitin Andrey"
+    :license "LLGPL"
     :depends-on (#:cffi #:hunchentoot #:bordeaux-threads
                  #:routes #:alexandria #:data-sift)
     :pathname "src"


### PR DESCRIPTION
Hello,

This is intended to fix #33.

I took the liberty to add Quicklisp's metadata to RESTAS's ASDF system.

I only use information that are publicly available, so please excuse any mistakes I made.

Best regards.