### PR TITLE
Fixed a grammar mistake in the ASDF's description

### DIFF
--- a/restas.asd
+++ b/restas.asd
@@ -7,7 +7,7 @@
 
 (defsystem #:restas
     :description "RESTAS is a Common Lisp web application framework, based
-on the Hunchentoot HTTP server It was developed to simplify development of
+on the Hunchentoot HTTP server. It was developed to simplify development of
 web applications following the REST architectural style."
     :author "Moskvitin Andrey"
     :license "LLGPL"


### PR DESCRIPTION
Sorry, I just now noticed a small grammatical mistake in the ASDF's description in my last commit/pull request. This pull request corrects the mistake.