### PR TITLE
Allow route to customize RENDER-METHOD instance

### DIFF
--- a/docs/en/ref/index.txt
+++ b/docs/en/ref/index.txt
@@ -72,6 +72,10 @@ Special variables
 
   The current route being handled.
 
+.. defvar:: restas:*render-method*
+
+  The render method for the current route being handled.
+
 Routes
 ======
 
@@ -100,7 +104,7 @@ Routes
 
   * :headers - *plist* with HTTP headers names and values. A union with :var:`*default-headers*` is used, with route option taking precedence.
 
-  * :render-method - object, used by call to :fun:`restas:render-object` for processing of
+  * :render-method - form to create an object, used by call to :fun:`restas:render-object` for processing of
     the result of route handler before serving it to client.
 
   * :apply-render-method - analogous to :render-method, but is called using
@@ -181,7 +185,7 @@ Modules
   Initializes a new module, creates new :hs:`package`, adds certain service variables to it, and conducts its initialization.
 
 .. defun:: restas:initialize-module-instance
-  :args: (module context) 
+  :args: (module context)
 
   It is a generic function that calling  when the module is mounted with :macro:`restas:mount-module`
   and can be used, for example, for additional adjustment of submodule context.
@@ -234,7 +238,7 @@ View
   (specified in the body of :macro:`restas:define-route`). If you didn't specify
   :render-method parameter for :macro:`restas:define-route` macro then the value of
   :var:`*default-render-method*` from the module where the current route being handled was
-  defined (It is automatically created at module definition time by macro 
+  defined (It is automatically created at module definition time by macro
   :macro:`restas:define-module` and its value is :hs:`NIL`) is used.
 
   For more detailed description see the section :ref:`manual-view`.

--- a/docs/ru/ref/index.txt
+++ b/docs/ru/ref/index.txt
@@ -28,7 +28,7 @@ API Reference
 
   * acceptor-class - символ, который определяет какой класс должен использоваться для создания
     acceptor. Данный класс должен наследовать от :class:`restas:restas-acceptor`
-    или :class:`restas:restas-ssl-acceptor`. 
+    или :class:`restas:restas-ssl-acceptor`.
 
   * ssl-certificate-file - путь к файлу-сертификату. Указывается для соединения по
     протоколу SSL (на Lispworks можно использовать один файл содержащий и сертификат
@@ -38,7 +38,7 @@ API Reference
 
   * ssl-privatekey-password - пароль (как строка) для использования файла-ключа (или
     NIL, что задано по умолчанию, если пароль не требуется).
-  
+
 
   Данная функция может быть вызвана несколько раз с различными параметрами. Если
   разные модули были запущены для одной и той же комбинации имени хости и номера
@@ -74,6 +74,10 @@ API Reference
 
   Обрабатываемый маршрут.
 
+.. defvar:: restas:*render-method*
+
+   Объект представления обрабатываемого маршрута.
+
 Маршруты
 ========
 
@@ -88,7 +92,7 @@ API Reference
   * template - шаблон URL, на основе которого проверяется соответствие маршрута
     запросу. Может содержать переменные, которые непосредственно доступны в
     теле маршрута.
-    
+
   * method - тип обрабатываемого HTTP-запроса, возможные значения: :GET, :POST,
     :PUT, :DELETE.
 
@@ -105,7 +109,7 @@ API Reference
     Используется объединение с :var:`*default-headers*`, причем в случае
     конфликта используются значения из опции маршрута.
 
-  * :render-method - объект, который будет использоваться в вызове :fun:`restas:render-object`
+  * :render-method - форма для создания объекта, который будет использоваться в вызове :fun:`restas:render-object`
     для обработки результата маршрута перед отдачей его клиенту.
 
   * :apply-render-method - аналогично :render-method, но для вызова
@@ -190,7 +194,7 @@ API Reference
   (добавляет в него некоторые служебные переменные)
 
 .. defun:: restas:initialize-module-instance
-  :args: (module context) 
+  :args: (module context)
 
   Generic-функция, вызывается при подключении модуля с помощью :macro:`restas:mount-module`.
   Может использваться, например, для дополнительной настройки контекста
@@ -253,7 +257,7 @@ API Reference
 Контекст
 ========
 
-В `RESTAS`_ для обеспечения модульности используется механизм, напоминающий 
+В `RESTAS`_ для обеспечения модульности используется механизм, напоминающий
 `Buffer-Local Variables`_ в `GNU Emacs`_.
 
 .. defmacro:: restas:make-context
@@ -279,7 +283,7 @@ API Reference
     вызова :hs:`symbol-value`.
 
 .. defun:: restas:context-remove-variable
-  :args: context symbol 
+  :args: context symbol
 
   Удаляет переменную из контекста
 

--- a/src/declarations.lisp
+++ b/src/declarations.lisp
@@ -53,7 +53,7 @@
   (when (cdr declarations)
     (error "Multiple instances of ~A declaration" type))
   (setf (gethash type traits)
-        (first declarations)))
+        `(alexandria:named-lambda make-route-render-method () ,(first declarations))))
 
 (defmethod parse-declarations ((type (eql :apply-render-method))
                                declarations traits)

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -10,6 +10,7 @@
   (:use :cl :iter :split-sequence)
   (:export #:*default-host-redirect*
            #:*route*
+           #:*render-method*
            #:*module*
 
            ;; acceptors

--- a/src/special.lisp
+++ b/src/special.lisp
@@ -13,6 +13,8 @@
 
 (defvar *route* nil)
 
+(defvar *render-method* nil)
+
 (defvar *module* nil)
 
 (defvar *catch-errors-p* t)


### PR DESCRIPTION
Sometimes RENDER-METHOD should be changed or replaced during route
processing. For example, rendering JSON may require different levels
of detail depending on additional request parameters. For this case
RENDER-METHOD made available via *RENDER-METHOD* special variable
inside the route body. To prevent clashing of the concurrent route
processing the :RENDER-METHOD option handles its value as a form which
is evaluated to get render method immediately before route processing.
This allows to have separate instances of render method for every invocation.