### PR TITLE
Add customizations to ROUTE and MOUNT-MODULE declarations

### DIFF
--- a/src/declarations.lisp
+++ b/src/declarations.lisp
@@ -7,6 +7,14 @@
 
 (in-package :restas)
 
+(defvar *route-declarations* '(:sift-variables :additional-variables
+                               :render-method :apply-render-method
+                               :content-type :http-method
+                               :requirement
+                               :decorators))
+(defvar *mount-module-declarations* '(:decorators :url :render-method
+                                      :inherit-parent-context))
+
 (defun split-code-declarations (body)
   (let ((declarations-map (make-hash-table))
         (code body))
@@ -19,10 +27,12 @@
                         (gethash (car form) declarations-map))))
     (values declarations-map code)))
 
-(defmethod parse-declarations (type declarations traits)
+(defgeneric parse-declarations (type declarations target traits))
+
+(defmethod parse-declarations (type declarations target traits)
   (error "Unknown type of declaration: ~A" type))
 
-(defmethod parse-declarations ((type (eql :sift-variables)) declarations traits)
+(defmethod parse-declarations ((type (eql :sift-variables)) declarations target traits)
   (let ((variables (gethash :variables traits)))
     (setf (gethash :parse-vars traits)
           (cons 'list
@@ -31,7 +41,7 @@
                       (collect `(data-sift:compile-parse-rule ,rule)))))))
 
 (defmethod parse-declarations ((type (eql :additional-variables))
-                               declarations traits)
+                               declarations target traits)
   (iter (for (var handler default) in declarations)
         (collect (if default
                      (list var default)
@@ -49,58 +59,70 @@
          (setf (gethash :additional-variables-arglist traits) (cons '&key arglist)
                (gethash :additional-variables traits) (cons 'list handlers)))))
 
-(defmethod parse-declarations ((type (eql :render-method)) declarations traits)
+(defmethod parse-declarations ((type (eql :render-method)) declarations target traits)
   (when (cdr declarations)
     (error "Multiple instances of ~A declaration" type))
   (setf (gethash type traits)
         `(alexandria:named-lambda make-route-render-method () ,(first declarations))))
 
 (defmethod parse-declarations ((type (eql :apply-render-method))
-                               declarations traits)
+                               declarations target traits)
   (when (cdr declarations)
     (error "Multiple instances of ~A declaration" type))
   (setf (gethash :render-method traits)
         `(alexandria:named-lambda apply-render-method (data)
            (apply ,(first declarations) data))))
 
-(defmethod parse-declarations ((type (eql :content-type)) declarations traits)
+(defmethod parse-declarations ((type (eql :content-type)) declarations target traits)
   (when (cdr declarations)
     (error "Multiple instances of ~A declaration" type))
   (setf (gethash type traits)
         (first declarations)))
 
-(defmethod parse-declarations ((type (eql :decorators)) declarations traits)
+(defmethod parse-declarations ((type (eql :decorators)) declarations target traits)
   (setf (gethash type traits)
         (cons 'list declarations)))
 
-(defmethod parse-declarations ((type (eql :http-method)) declarations traits)
+(defmethod parse-declarations ((type (eql :http-method)) declarations target traits)
   (when (cdr declarations)
     (error "Multiple instances of ~A declaration" type))
   (setf (gethash :method traits)
         (first declarations)))
 
-(defmethod parse-declarations ((type (eql :requirement)) declarations traits)
+(defmethod parse-declarations ((type (eql :requirement)) declarations target traits)
   (setf (gethash type traits) (cons 'list declarations)))
 
-(defmethod parse-declarations ((type (eql :url)) declarations traits)
+(defmethod parse-declarations ((type (eql :url)) declarations target traits)
   (when (cdr declarations)
     (error "Multiple instances of ~A declaration" type))
   (setf (gethash :url traits)
         (first declarations)))
 
 (defmethod parse-declarations ((type (eql :inherit-parent-context))
-                               declarations traits)
+                               declarations target traits)
   (when (cdr declarations)
     (error "Multiple instances of ~A declaration" type))
   (setf (gethash :inherit-parent-context traits)
         (first declarations)))
 
-(defun parse-all-declarations (declarations allowed-types &optional traits)
+(defun parse-all-declarations (declarations allowed-types target &optional traits)
   (let ((traits (or traits (make-hash-table))))
     (iter (for (key value) in-hashtable declarations)
           (cond
             ((member key allowed-types)
-             (parse-declarations key value traits))
+             (parse-declarations key value target traits))
             (t
              (error "Unknown declaration type: ~A" key))))
     traits))
+
+(defmacro define-declaration (declaration scope (declarations target traits) &body body)
+  `(progn
+     (case ,scope
+       (:route
+        (pushnew ,declaration restas::*route-declarations*))
+       (:mount-module
+           (pushnew ,declaration restas::*mount-module-declarations*))
+       (t
+        (error "Unknown declaration scope: ~A, allowed are ROUTE and MOUNT-MODULE" ,scope)))
+     (defmethod restas::parse-declarations ((type (eql ,declaration)) ,declarations ,target ,traits)
+       ,@body)))

--- a/src/module.lisp
+++ b/src/module.lisp
@@ -271,8 +271,8 @@ MODULE should be the name used for mount-module."
     (let ((bindings (iter (for (symbol value) in context)
                           (collect `(cons ',symbol ,value))))
           (traits (parse-all-declarations declarations
-                                          '(:decorators :url :render-method
-                                            :inherit-parent-context))))
+                                          name
+                                          *mount-module-declarations*)))
     `(progn
        (setf (gethash ',name (pkgmodule-traits-modules *package*))
              (list ',module

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -65,6 +65,7 @@
            
            ;; misc
            #:request-full-uri
+           #:define-declaration
 
            ;; decorators
            #:@no-cache

--- a/src/route.lisp
+++ b/src/route.lisp
@@ -99,11 +99,8 @@
             (gethash :variables route-traits) variables)
 
       (parse-all-declarations declarations-map
-                              '(:sift-variables :additional-variables
-                                :render-method :apply-render-method
-                                :content-type :http-method
-                                :requirement
-                                :decorators)
+                              *route-declarations*
+                              name
                               route-traits)
 
       (setf (gethash :variables route-traits) `',arglist)


### PR DESCRIPTION
New declarations can be added via DEFINE-DECLARATION macro
which allow invocation of it body with parameters DECLARATIONS,
TARGET and TRAITS. DECLARATIONS contains values of declaration,
TARGET contains target symbol of ROUTE or MOUNT-MODULE and TRAITS
contains hash-map of all traits.