### PR TITLE
Change the symbol +HTTP-NOT-FOUND+ to lower case

### DIFF
--- a/src/hunchentoot.lisp
+++ b/src/hunchentoot.lisp
@@ -87,7 +87,7 @@
     (flet ((not-found-if-null (thing)
              (unless thing
                (setf (hunchentoot:return-code*)
-                     hunchentoot:+HTTP-NOT-FOUND+)
+                     hunchentoot:+http-not-found+)
                (hunchentoot:abort-request-handler))))
       (not-found-if-null vhost)
       (multiple-value-bind (route bindings)


### PR DESCRIPTION
This trivial change allow RESTAS to be compatible with
Allegro CL Modern mode and is transparent to others CL
implementations.